### PR TITLE
feat: Enhance glob support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,107 @@
+# Copilot Instructions: Babel Plugin Shopware Vite Meta Glob
+
+This is a specialized Babel plugin that transforms `import.meta.glob()` calls
+into dynamic imports or eager requires, bridging Vite's glob functionality for
+Shopware and Babel environments.
+
+## Core Architecture
+
+**Single Entry Point**: `src/index.ts` exports the main plugin function that
+returns a Babel visitor pattern
+
+- Plugin transforms AST nodes by visiting `CallExpression` nodes
+- Supports two transformation modes: lazy imports (`() => import()`) and eager
+  requires (`require()`)
+- Uses `glob` package for file system globbing relative to source file directory
+
+## Key Transformation Patterns
+
+### Lazy Loading (Default)
+
+```javascript
+// Input: import.meta.glob('./dir/*.js')
+// Output: { './dir/file.js': () => import('./dir/file.js') }
+
+// Input: import.meta.glob(['./dir1/*.js', './dir2/*.js'])
+// Output: { './dir1/file.js': () => import('./dir1/file.js'), './dir2/file.js': () => import('./dir2/file.js') }
+```
+
+### Eager Loading
+
+```javascript
+// Input: import.meta.glob('./dir/*.js', { eager: true })
+// Output: Generates require() calls wrapped in IIFE pattern
+
+// Input: import.meta.glob(['./file1.js', './file2.js'], { eager: true })
+// Output: IIFE pattern with require() calls for each file in array
+```
+
+### Import Specific Export
+
+```javascript
+// Input: import.meta.glob('./dir/*.js', { eager: true, import: 'default' })
+// Output: require('./path').default pattern
+
+// Input: import.meta.glob(['./file1.js', './file2.js'], { eager: true, import: 'default' })
+// Output: IIFE pattern with require('./path').default for each file
+```
+
+## Critical Constraints & Limitations
+
+- **Supports both string and array patterns** - handles single strings
+  `'./dir/*.js'` and arrays `['./dir1/*.js', './dir2/*.js']`
+- **Eager-only import option** - `{ import: 'default' }` only works with
+  `{ eager: true }`
+- **No query support** - `{ query: 'foo' }` option is ignored
+- **Development warning** - Plugin includes production usage warning in README
+
+## Testing Strategy
+
+Uses `babel-plugin-tester` with snapshot testing in `src/__tests__/index.ts`:
+
+- **Positive tests**: Valid transformations with different option combinations
+  - String patterns: `import.meta.glob('./dir/*.js')`
+  - Array patterns: `import.meta.glob(['./file1.js', './file2.js'])`
+  - Eager loading: Both string and array patterns with `{ eager: true }`
+  - Import options: Both patterns with `{ eager: true, import: 'default' }`
+- **Negative tests**: Cases that should NOT be transformed
+- **Fixture files**: `src/__tests__/fixtures/file{1,2,3}.ts` for glob pattern
+  testing
+- Test snapshots show exact expected AST transformations
+
+## Build & Development Workflow
+
+```bash
+npm run build        # Uses kcd-scripts to compile TypeScript to lib/
+npm test            # Runs tests with snapshots
+npm run format      # Code formatting via kcd-scripts
+npm run prepublish  # Auto-builds before publishing
+```
+
+## Debugging
+
+Set `DEBUG=babel-plugin-shopware-vite-meta-glob` environment variable for
+detailed transformation logging. The plugin uses `debug` package to log:
+
+- Source files being processed
+- Resolved glob patterns
+- Final replacement AST nodes
+
+## File Organization
+
+- `src/index.ts` - Main plugin implementation with Babel visitor pattern
+- `lib/` - Compiled JavaScript output (auto-generated, don't edit)
+- `src/__tests__/` - Test suite with snapshots and fixtures
+- Uses `kcd-scripts` for consistent tooling across build/test/format
+
+## AST Transformation Details
+
+The plugin generates different AST patterns based on options:
+
+- **Dynamic imports**: Arrow functions returning `import()` calls
+- **Eager requires**: IIFE pattern with variable declarations and object
+  construction
+- **Path normalization**: Converts Windows backslashes to forward slashes
+- **Sorted output**: Glob results are sorted for deterministic transforms
+- **Array pattern processing**: Uses `extractPatterns()` helper to handle both
+  single strings and arrays of glob patterns uniformly

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,8 @@ jobs:
         id: node-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key:
+            node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies (if the cached directory was not found)
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -25,4 +26,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          access: "public"
+          access: 'public'

--- a/README.md
+++ b/README.md
@@ -14,21 +14,26 @@ main transformation strategies:
 > thoroughly test before considering any production deployment.
 
 ## Disclaimer
-This plugin was heavily inspired from the [OpenSourceRaidGuild/babel-vite](https://github.com/OpenSourceRaidGuild/babel-vite) repo. Unfortunately for us it was not handling the import meta statements right for our use case.
-Since this was time critical we decided to create our own version. If there version works for you stick to theirs!
+
+This plugin was heavily inspired from the
+[OpenSourceRaidGuild/babel-vite](https://github.com/OpenSourceRaidGuild/babel-vite)
+repo. Unfortunately for us it was not handling the import meta statements right
+for our use case. Since this was time critical we decided to create our own
+version. If there version works for you stick to theirs!
 
 ## Supported Features
 
-- Transforms `import.meta.glob('./dir/*.js')` into an object of dynamic imports
-- Supports `{ eager: true }` option for direct module imports
-- Supports `{ import: 'default' }` **only in combination with eager: true**
-- Handles file path normalization
-- Works with both Windows and Unix-style file paths
+- ✅ Transforms `import.meta.glob('./dir/*.js')` into an object of dynamic
+  imports
+- ✅ Transforms `import.meta.glob(['./dir1/*.js', './dir2/*.js'])` array
+  patterns
+- ✅ Supports `{ eager: true }` option for direct module imports
+- ✅ Supports `{ import: 'default' }` **only in combination with eager: true**
+- ✅ Handles file path normalization
+- ✅ Works with both Windows and Unix-style file paths
 
 ## Unsupported Features
 
-- **Doesn't transform** `import.meta.glob(['./dir1/*.js', './dir2/*.js'])` array
-  like syntax
 - **Doesn't transform** `import.meta.glob('./dir1/*.js', { eager: false })`
   eager false will not be transformed
 - **Doesn't transform** `import.meta.glob('./dir1/*.js', { query: 'foo' })`
@@ -78,6 +83,39 @@ const modules = {
   './dir/file1.js': require('./dir/file1.js'),
   './dir/file2.js': require('./dir/file2.js'),
 }
+```
+
+### Array Pattern Support
+
+The plugin now supports array patterns for specifying multiple file patterns:
+
+```javascript
+// Input with array patterns (lazy loading)
+const modules = import.meta.glob(['./components/*.vue', './utils/*.js'])
+
+// Transformed output
+const modules = {
+  './components/Button.vue': () => import('./components/Button.vue'),
+  './components/Modal.vue': () => import('./components/Modal.vue'),
+  './utils/helper.js': () => import('./utils/helper.js'),
+  './utils/api.js': () => import('./utils/api.js'),
+}
+
+// Input with array patterns and eager loading
+const modules = import.meta.glob(['./src/file1.js', './src/file2.js'], {
+  eager: true,
+})
+
+// Transformed output (IIFE pattern)
+const modules = (function () {
+  const __glob__0_0 = require('./src/file1.js')
+  const __glob__0_1 = require('./src/file2.js')
+  const __glob__context__ = {
+    './src/file1.js': __glob__0_0,
+    './src/file2.js': __glob__0_1,
+  }
+  return __glob__context__
+})()
 ```
 
 ## Options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "babel-plugin-shopware-vite-meta-glob",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babel-plugin-shopware-vite-meta-glob",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.0.2",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.9",
         "@types/babel__core": "^7.1.12",
@@ -21,6 +21,10 @@
         "babel-plugin-tester": "^10.0.0",
         "kcd-scripts": "^16.0.0",
         "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-shopware-vite-meta-glob",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/shopware/babel-plugin-shopware-vite-meta-glob",
   "bugs": {
     "url": "https://github.com/shopware/babel-plugin-shopware-vite-meta-glob/issues"
@@ -32,7 +32,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0",
+    "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0",
     "npm": ">=10.0.0"
   }
 }

--- a/src/__tests__/__snapshots__/index.ts.snap
+++ b/src/__tests__/__snapshots__/index.ts.snap
@@ -13,17 +13,6 @@ const modules = import.meta.glob("./fixtures/**/*", {
 
 `;
 
-exports[`vite-meta-glob should not transform glob with first argument being an array: should not transform glob with first argument being an array 1`] = `
-
-const modules = import.meta.glob(["./fixtures/**/*", "./fixtures/specific.js"])
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-const modules = import.meta.glob(["./fixtures/**/*", "./fixtures/specific.js"]);
-
-
-`;
-
 exports[`vite-meta-glob should not transform glob with import option without eager: should not transform glob with import option without eager 1`] = `
 
 const modules = import.meta.glob("./fixtures/**/*", { import: "default" })
@@ -44,6 +33,58 @@ const modules = import.meta.env("./fixtures/**/*")
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const modules = import.meta.env("./fixtures/**/*");
+
+
+`;
+
+exports[`vite-meta-glob should transform glob with array patterns: should transform glob with array patterns 1`] = `
+
+const modules = import.meta.glob(["./fixtures/file1.ts", "./fixtures/file2.ts"])
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = {
+  "./fixtures/file1.ts": () => import("./fixtures/file1.ts"),
+  "./fixtures/file2.ts": () => import("./fixtures/file2.ts"),
+};
+
+
+`;
+
+exports[`vite-meta-glob should transform glob with array patterns and eager option: should transform glob with array patterns and eager option 1`] = `
+
+const modules = import.meta.glob(["./fixtures/file1.ts", "./fixtures/file2.ts"], { eager: true })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = (function () {
+  const __glob__0_0 = require("./fixtures/file1.ts");
+  const __glob__0_1 = require("./fixtures/file2.ts");
+  const __glob__context__ = {
+    "./fixtures/file1.ts": __glob__0_0,
+    "./fixtures/file2.ts": __glob__0_1,
+  };
+  return __glob__context__;
+})();
+
+
+`;
+
+exports[`vite-meta-glob should transform glob with array patterns and eager and import option: should transform glob with array patterns and eager and import option 1`] = `
+
+const modules = import.meta.glob(["./fixtures/file1.ts", "./fixtures/file2.ts"], { eager: true, import: "default" })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = (function () {
+  const __glob__0_0 = require("./fixtures/file1.ts").default;
+  const __glob__0_1 = require("./fixtures/file2.ts").default;
+  const __glob__context__ = {
+    "./fixtures/file1.ts": __glob__0_0,
+    "./fixtures/file2.ts": __glob__0_1,
+  };
+  return __glob__context__;
+})();
 
 
 `;

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -23,12 +23,18 @@ pluginTester({
     'should transform glob with eager and import option': withFileName(
       'const modules = import.meta.glob("./fixtures/**/*", { eager: true, import: "default" })',
     ),
+    'should transform glob with array patterns': withFileName(
+      'const modules = import.meta.glob(["./fixtures/file1.ts", "./fixtures/file2.ts"])',
+    ),
+    'should transform glob with array patterns and eager option': withFileName(
+      'const modules = import.meta.glob(["./fixtures/file1.ts", "./fixtures/file2.ts"], { eager: true })',
+    ),
+    'should transform glob with array patterns and eager and import option':
+      withFileName(
+        'const modules = import.meta.glob(["./fixtures/file1.ts", "./fixtures/file2.ts"], { eager: true, import: "default" })',
+      ),
 
     // Negative tests
-    'should not transform glob with first argument being an array':
-      withFileName(
-        'const modules = import.meta.glob(["./fixtures/**/*", "./fixtures/specific.js"])',
-      ),
     'should not transform glob with eager option being false': withFileName(
       'const modules = import.meta.glob("./fixtures/**/*", { eager: false })',
     ),


### PR DESCRIPTION
This pull request adds support for array patterns in `import.meta.glob()` calls, allowing multiple glob patterns to be specified in an array. It updates the plugin logic, documentation, and test suite to reflect this new capability, while also making minor improvements and fixes across the codebase.

**Major feature: Array pattern support in glob imports**

- **Plugin logic and transformation:**
  - Refactored the Babel plugin (`src/index.ts`) to extract and process array patterns as the first argument to `import.meta.glob()`, enabling transformation for both single string and array-of-strings patterns. The transformation now correctly handles both lazy and eager loading modes for arrays.
- **Test suite updates:**
  - Added new positive tests for array pattern support (including eager and import options) and removed obsolete negative tests that previously asserted array patterns were not supported. Updated test snapshots to match the new expected output. (`src/__tests__/index.ts`, `src/__tests__/__snapshots__/index.ts.snap`)
- **Documentation updates:**
  - Updated `README.md` to document array pattern support, including examples for both lazy and eager loading. Added a new section demonstrating the transformation of array patterns.
  - Added a new `.github/copilot-instructions.md` file with a comprehensive technical overview of the plugin, including architecture, transformation patterns, constraints, and testing strategy.

**Other improvements and maintenance**

- **Package and workflow updates:**
  - Bumped the package version to `0.0.3` and updated Node.js engine support to include Node 24 in `package.json`.

These changes make the plugin more flexible and robust, allowing it to handle a broader set of use cases for glob imports in Babel environments.